### PR TITLE
Remove neutron-gateway

### DIFF
--- a/tests/bundles/focal-ussuri.yaml
+++ b/tests/bundles/focal-ussuri.yaml
@@ -135,14 +135,6 @@ applications:
       neutron-security-groups: true
       openstack-origin: *openstack-origin
     constraints: mem=1024
-  neutron-gateway:
-    charm: cs:~openstack-charmers-next/neutron-gateway
-    num_units: 1
-    options:
-      bridge-mappings: physnet1:br-ex
-      instance-mtu: 1300
-      openstack-origin: *openstack-origin
-    constraints: mem=4096
   neutron-mysql-router:
     charm: cs:~openstack-charmers-next/mysql-router
   nova-cloud-controller:
@@ -252,8 +244,6 @@ relations:
   - cinder-ceph:storage-backend
 - - cinder-ceph:ceph
   - ceph-mon:client
-- - neutron-gateway:quantum-network-service
-  - nova-cloud-controller:quantum-network-service
 - - openstack-dashboard:identity-service
   - keystone:identity-service
 - - swift-proxy:identity-service
@@ -278,16 +268,12 @@ relations:
   - keystone:identity-service
 - - heat:amqp
   - rabbitmq-server:amqp
-- - neutron-gateway:amqp
-  - rabbitmq-server:amqp
 - - neutron-api:amqp
   - rabbitmq-server:amqp
 - - neutron-api:neutron-api
   - nova-cloud-controller:neutron-api
 - - neutron-api:identity-service
   - keystone:identity-service
-- - neutron-api:neutron-plugin-api
-  - neutron-gateway:neutron-plugin-api
 - - ceph-osd:mon
   - ceph-mon:osd
 - - aodh:amqp


### PR DESCRIPTION
The Neutron Gateway should not be present in a OVN deployment.

The Zaza basic overcloud network job will attach an extra interface
on units with the ovn-chassis subordinate set the
``bridge-interface-mappings`` and ``ovn-bridge-mappings``
configuration options for you.